### PR TITLE
Add Support for Passing Instance Profile to EC2 Instance Creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ magefile
 
 # Test Artifacts
 testFile
+pkg/ec2/test_env

--- a/pkg/ec2/README.md
+++ b/pkg/ec2/README.md
@@ -1,0 +1,17 @@
+## Running the Tests
+
+You'll need a bunch of environment variables to run these tests.
+The easiest way to do this is to copy and fill in the provided template:
+
+```
+cp test_env_template test_env
+```
+
+Fill in all of the `export` commands in `test_env` with the appropriate values, 
+then source the file to add the environment variables to your shell:
+
+```
+source test_env
+```
+
+Note that your `test_env` file is gitignored.

--- a/pkg/ec2/ec2.go
+++ b/pkg/ec2/ec2.go
@@ -22,6 +22,7 @@ type Connection struct {
 type Params struct {
 	AssociatePublicIPAddress bool
 	ImageID                  string
+	InstanceProfile          string
 	InstanceType             string
 	MinCount                 int
 	MaxCount                 int
@@ -32,7 +33,6 @@ type Params struct {
 	InstanceID               string
 	InstanceName             string
 	PublicIP                 string
-	IamInstanceProfile	 string
 }
 
 // createClient is a helper function that
@@ -70,7 +70,9 @@ func CreateInstance(client *ec2.EC2, ec2Params Params) (*ec2.Reservation, error)
 				},
 			},
 		},
-		IamInstanceProfile: aws.String(ec2Params.IamInstanceProfile),
+		IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
+			Name: aws.String(ec2Params.InstanceProfile),
+		},
 		ImageId:      aws.String(ec2Params.ImageID),
 		InstanceType: aws.String(ec2Params.InstanceType),
 		MinCount:     aws.Int64(int64(ec2Params.MinCount)),

--- a/pkg/ec2/ec2.go
+++ b/pkg/ec2/ec2.go
@@ -32,6 +32,7 @@ type Params struct {
 	InstanceID               string
 	InstanceName             string
 	PublicIP                 string
+	IamInstanceProfile	 string
 }
 
 // createClient is a helper function that
@@ -69,6 +70,7 @@ func CreateInstance(client *ec2.EC2, ec2Params Params) (*ec2.Reservation, error)
 				},
 			},
 		},
+		IamInstanceProfile: aws.String(ec2Params.IamInstanceProfile),
 		ImageId:      aws.String(ec2Params.ImageID),
 		InstanceType: aws.String(ec2Params.InstanceType),
 		MinCount:     aws.Int64(int64(ec2Params.MinCount)),

--- a/pkg/ec2/ec2_test.go
+++ b/pkg/ec2/ec2_test.go
@@ -22,6 +22,7 @@ var (
 		ImageID:                  os.Getenv("AMI"),
 		InstanceName:             os.Getenv("INST_NAME"),
 		InstanceType:             os.Getenv("INST_TYPE"),
+		InstanceProfile:          os.Getenv("INST_PROFILE"),
 		MinCount:                 1,
 		MaxCount:                 1,
 		SecurityGroupIDs:         []string{os.Getenv("SEC_GRP_ID")},

--- a/pkg/ec2/test_env
+++ b/pkg/ec2/test_env
@@ -1,6 +1,6 @@
 export AMI=ami-0ca285d4c2cda3300
 export PUB_IP=true
-export INST_NAME=awutils-ec2-test
+export INST_NAME=awsutils-ec2-test
 export INST_PROFILE=instance-deployer-workloads-default-instance-profile
 export INST_TYPE=t3.micro
 export SEC_GRP_ID=sg-02ad6f282d58c0bd9

--- a/pkg/ec2/test_env
+++ b/pkg/ec2/test_env
@@ -1,7 +1,8 @@
-export AMI=TODO
+export AMI=ami-0ca285d4c2cda3300
 export PUB_IP=true
-export INST_NAME=TODO
-export INST_TYPE=t2.micro
-export SEC_GRP_ID=TODO
-export SUBNET_ID=TODO
+export INST_NAME=awutils-ec2-test
+export INST_PROFILE=instance-deployer-workloads-default-instance-profile
+export INST_TYPE=t3.micro
+export SEC_GRP_ID=sg-02ad6f282d58c0bd9
+export SUBNET_ID=subnet-0ee8e828a3ea7d05f
 export VOLUME_SIZE=100

--- a/pkg/ec2/test_env
+++ b/pkg/ec2/test_env
@@ -1,8 +1,0 @@
-export AMI=ami-0ca285d4c2cda3300
-export PUB_IP=true
-export INST_NAME=awsutils-ec2-test
-export INST_PROFILE=instance-deployer-workloads-default-instance-profile
-export INST_TYPE=t3.micro
-export SEC_GRP_ID=sg-02ad6f282d58c0bd9
-export SUBNET_ID=subnet-0ee8e828a3ea7d05f
-export VOLUME_SIZE=100

--- a/pkg/ec2/test_env_template
+++ b/pkg/ec2/test_env_template
@@ -1,0 +1,7 @@
+export AMI=TODO
+export PUB_IP=true
+export INST_NAME=TODO
+export INST_TYPE=t2.micro
+export SEC_GRP_ID=TODO
+export SUBNET_ID=TODO
+export VOLUME_SIZE=100


### PR DESCRIPTION
Tests pass: 

```
➜  ec2 git:(sfm-instance-profile) ✗ go test
Successfully created instance: i-088f647ed0362fa0d
2022/06/09 10:54:58 Running instance IDs:
i-0ce6f9735343a44f6
i-04d9c931f1982cd4b
i-04105b2d07fec860f

Successfully grabbed public IP: 44.226.198.78
Successfully grabbed instance state: running
PASS
ok  	github.com/l50/awsutils/pkg/ec2	200.695s
➜  ec2 git:(sfm-instance-profile) ✗
```